### PR TITLE
feat: Add add_grants_to_existing_objects flag to the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ which can be executed manually in Snowflake account.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_add_grants_to_existing_objects"></a> [add\_grants\_to\_existing\_objects](#input\_add\_grants\_to\_existing\_objects) | Whether grants to existing objects should be added | `bool` | `false` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_comment"></a> [comment](#input\_comment) | Specifies a comment for the schema | `string` | `null` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -15,7 +15,7 @@ locals {
     granted_roles                  = []
     granted_to_roles               = []
     granted_to_users               = []
-    add_grants_to_existing_objects = false
+    add_grants_to_existing_objects = var.add_grants_to_existing_objects
     schema_grants                  = []
     table_grants                   = []
     dynamic_table_grants           = []

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "create_default_roles" {
   default     = false
 }
 
+variable "add_grants_to_existing_objects" {
+  description = "Whether grants to existing objects should be added"
+  type        = bool
+  default     = false
+}
+
 variable "roles" {
   description = "Roles created in the scheme scope"
   type = map(object({


### PR DESCRIPTION
Added `add_grants_to_existing_objects` flag/variable to allow adding grants to all existing objects and roles within schema