### PR TITLE
chore: Bump snowflake stage module to newest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ List od code and variable (API) changes:
 | <a name="module_roles_deep_merge"></a> [roles\_deep\_merge](#module\_roles\_deep\_merge) | Invicton-Labs/deepmerge/null | 0.1.5 |
 | <a name="module_snowflake_custom_role"></a> [snowflake\_custom\_role](#module\_snowflake\_custom\_role) | getindata/database-role/snowflake | 2.1.0 |
 | <a name="module_snowflake_default_role"></a> [snowflake\_default\_role](#module\_snowflake\_default\_role) | getindata/database-role/snowflake | 2.1.0 |
-| <a name="module_snowflake_stage"></a> [snowflake\_stage](#module\_snowflake\_stage) | getindata/stage/snowflake | 3.1.0 |
+| <a name="module_snowflake_stage"></a> [snowflake\_stage](#module\_snowflake\_stage) | getindata/stage/snowflake | 3.1.1 |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ module "snowflake_stage" {
   for_each = var.stages
 
   source  = "getindata/stage/snowflake"
-  version = "3.1.0"
+  version = "3.1.1"
 
   context_templates = var.context_templates
 


### PR DESCRIPTION
Bump `terraform-snowflake-stage` module to newest version, in order to fix dependacy issue within parent modules.